### PR TITLE
to allow hcll-thermal.i to be generated

### DIFF
--- a/moose/kernels.py
+++ b/moose/kernels.py
@@ -235,15 +235,15 @@ class AuxKernels(Kernels):
         super().__init__()
         self.name = 'AuxKernels'
     
-    def add_kernel(self, name, type, variable, block, **kwargs):
+    def add_kernel(self, name, kernel_type, variable, block, **kwargs):
         if name in self.kernels.keys():
             print(f'aux kernel name {name} already in use')
 
-        if type == AuxKernelTypes.ParsedAux:
+        if kernel_type == AuxKernelTypes.ParsedAux:
             kernel = ParsedAux(name,variable,block, **kwargs)
-        elif type == AuxKernelTypes.ADRankTwoAux:
+        elif kernel_type == AuxKernelTypes.ADRankTwoAux:
             kernel = ADRankTwoAux(name,variable,block, **kwargs)
-        elif type == AuxKernelTypes.ADRankTwoScalarAux:
+        elif kernel_type == AuxKernelTypes.ADRankTwoScalarAux:
             kernel = ADRankTwoScalarAux(name,variable,block, **kwargs)
 
         self.kernels[name] = kernel  

--- a/moose/kernels.py
+++ b/moose/kernels.py
@@ -158,7 +158,7 @@ class ParsedAux(AuxKernel):
         string  = f'[{self.name}]\n'
         string += f'type={self.aux_kernel_type.name}\n'
         string += f'variable={self.variable.name}\n'
-        string += f'{self.function.__str__()}\n'
+        string += f'function={self.function.__str__()}\n'
         string += f'args={self.args.name}\n'
         string += '[]\n'
         return string

--- a/moose/kernels.py
+++ b/moose/kernels.py
@@ -158,7 +158,7 @@ class ParsedAux(AuxKernel):
         string  = f'[{self.name}]\n'
         string += f'type={self.aux_kernel_type.name}\n'
         string += f'variable={self.variable.name}\n'
-        string += f'{self.function.__str__()}'
+        string += f'{self.function.__str__()}\n'
         string += f'args={self.args.name}\n'
         string += '[]\n'
         return string

--- a/moose/materials.py
+++ b/moose/materials.py
@@ -156,9 +156,9 @@ class ADGenericFunctionMaterial(Material):
         string =  f'[{self.name}]\n'
         string += f'type={self.material_type.name}\n'
         prop_names = ' '.join(self.prop_names)
-        string += f'prop_names={prop_names}\n'
+        string += f'prop_names=\'{prop_names}\'\n'
         prop_values = ' '.join([x.name for x in self.prop_values])
-        string += f'prop_values={prop_values}\n'
+        string += f'prop_values=\'{prop_values}\'\n'
         if self.block:
             string += f'block="{self.block}"\n'
         string += '[]\n'

--- a/moose/mesh.py
+++ b/moose/mesh.py
@@ -18,23 +18,28 @@ class MeshObject():
         self.name = name
 
 class FileMeshGenerator(MeshObject):
-    def __init__(self, name = "", **kwargs):
+    def __init__(self, name="", **kwargs):
         super().__init__(name, **kwargs)
         self.mesh_object_type = MeshObjectTypes.FileMeshGenerator
         self.filename = kwargs.pop('filename')
         self.clear_spline_nodes = False
+        self.show_info = False
         if 'clear_spline_nodes' in kwargs.keys():
             self.clear_spline_nodes = True
-    
+        if 'show_info' in kwargs.keys():
+            self.show_info = True
+
     def __str__(self):
-        string  = f'[{self.name}]\n'
+        string = f'[{self.name}]\n'
         string += f'type={self.mesh_object_type.name}\n'
         string += f'file={self.filename}\n'
         if self.clear_spline_nodes:
             string += 'clear_spline_nodes=true\n'
+        if self.show_info:
+            string += 'show_info=true\n'
         string += '[]\n'
         return string
-
+        
 class TransformGenerator(MeshObject):
 
     def __init__(self, name = "", **kwargs):

--- a/moose/mesh.py
+++ b/moose/mesh.py
@@ -85,14 +85,16 @@ class Mesh():
 
         return string
 
-    def add_mesh_object(self, name = "", type = None, **kwargs):
+    def add_mesh_object(self, name="", mesh_type=None, **kwargs):
         if name in self.mesh_objects.keys():
-            print (f'name {name} already in use')
+            print(f'name {name} already in use')
 
-        if type == MeshObjectTypes.FileMeshGenerator:
+        if mesh_type == MeshObjectTypes.FileMeshGenerator:
             mesh = FileMeshGenerator(name=name, **kwargs)
-        elif type == MeshObjectTypes.TransformGenerator:
+        elif mesh_type == MeshObjectTypes.TransformGenerator:
             mesh = TransformGenerator(name=name, **kwargs)
-        
+        else:
+            raise ValueError(f'Invalid mesh object type: {mesh_type}')
+
         self.mesh_objects[name] = mesh
         

--- a/moose/moose.py
+++ b/moose/moose.py
@@ -45,6 +45,7 @@ class MOOSEInput():
         file = open(filename,'w')
         # first the mesh block
         if self.mesh: file.write(indent(self.mesh.__str__()))
+        if self.problem: file.write(indent(self.problem.__str__()))
         if self.global_params: file.write(indent(self.global_params.__str__()))
         if self.variables: file.write(indent(self.variables.__str__()))
         if self.aux_variables: file.write(indent(self.aux_variables.__str__()))

--- a/moose/problem.py
+++ b/moose/problem.py
@@ -1,0 +1,13 @@
+#!/usr/env/python3
+
+class ProblemType():
+    def __init__(self, name = "", **kwargs):
+        self.name = name
+        self.mesh_object_type = kwargs.pop('mesh_object_type')
+
+    def __str__(self):
+        string = f'\n[{self.name}]\n'
+        string += f'type={self.mesh_object_type}\n'
+        string += '[]\n\n'
+        return string
+

--- a/moose/variables.py
+++ b/moose/variables.py
@@ -55,8 +55,8 @@ class Variables():
         self.name = "Variables"
         self.variables = {}
 
-    def add_variable(self, name, order, family, block="", initial_condition=""):
-        variable = Variable(name=name, order=order, family=family, block=block, initial_condition=initial_condition)
+    def add_variable(self, name, **kwargs):
+        variable = Variable(name=name, **kwargs)
         if variable.name in self.variables.keys():
             print("variable name already in use")
             

--- a/moose/variables.py
+++ b/moose/variables.py
@@ -27,33 +27,27 @@ class Family(IntEnum):
     RATIONAL_BERNSTEIN = auto()
     SIDE_HIERARCHIC = auto()
     
-class Variable():
-    def __init__(self, name="", order=None, family=None, block=None, initial_condition=None):
+class Variable:
+    def __init__(self, name, order=None, **kwargs):
         self.name = name
         self.order = order
-        self.family = family
-        self.block = block
-        self.initial_condition = initial_condition
+        self.kwargs = kwargs
 
     def __str__(self):
         string = f'[{self.name}]\n'
-        if self.order != None:
-            string += f'order = {self.order.name}\n'
-        else:
-            string += f'order = {self.order}\n'
-        if self.family != None:
-            string += f'family = {self.family.name}\n'
-        else:
-            string += f'family = {self.family}\n'
-        if self.initial_condition:
-            string += f'initial_condition = "{self.initial_condition}"\n'
-        if self.block:
-            string += f'block = "{self.block}"\n'
+        if self.order is not None:
+            string += f'order = {Order(self.order).name}\n'
+        if 'family' in self.kwargs:
+            string += f'family = {self.kwargs["family"].name}\n'
+        if 'initial_condition' in self.kwargs:
+            string += f'initial_condition = "{self.kwargs["initial_condition"]}"\n'
+        if 'block' in self.kwargs and self.kwargs['block'] is not None:
+            string += f'block = "{self.kwargs["block"]}"\n'
         string += f'[]\n'
         return string
 
 class AuxVariable(Variable):
-    def __init__(self, name="",order=None, family=None, block=None, initial_condition=None):
+    def __init__(self, name="",**kwargs):
         super().__init__(name, order, family, block, initial_condition)
 
 class Variables():
@@ -61,11 +55,10 @@ class Variables():
         self.name = "Variables"
         self.variables = {}
 
-    def add_variable(self, name, order, family, block, initial_condition):
-        variable = Variable(name=name, order=order,family=family,block=block, initial_condition=initial_condition)
+    def add_variable(self, name, order=None, **kwargs):
+        variable = Variable(name=name, order=order, **kwargs)
         if variable.name in self.variables.keys():
             print("variable name already in use")
-            
         self.variables[variable.name] = variable
 
     def __str__(self):

--- a/moose/variables.py
+++ b/moose/variables.py
@@ -2,7 +2,7 @@
 
 from enum import IntEnum, auto
 
-class Order(IntEnum):
+class Order(IntEnum): 
     CONSTANT = auto()
     FIRST = auto()
     SECOND = auto()
@@ -28,17 +28,23 @@ class Family(IntEnum):
     SIDE_HIERARCHIC = auto()
     
 class Variable():
-    def __init__(self, name="", order=1, family=1, block="", initial_condition=""):
+    def __init__(self, name="", order=None, family=None, block=None, initial_condition=None):
         self.name = name
-        self.order = Order(order)
-        self.family = Family(family)
+        self.order = order
+        self.family = family
         self.block = block
         self.initial_condition = initial_condition
 
     def __str__(self):
         string = f'[{self.name}]\n'
-        string += f'order = {self.order.name}\n'
-        string += f'family = {self.family.name}\n'
+        if self.order != None:
+            string += f'order = {self.order.name}\n'
+        else:
+            string += f'order = {self.order}\n'
+        if self.family != None:
+            string += f'family = {self.family.name}\n'
+        else:
+            string += f'family = {self.family}\n'
         if self.initial_condition:
             string += f'initial_condition = "{self.initial_condition}"\n'
         if self.block:
@@ -47,7 +53,7 @@ class Variable():
         return string
 
 class AuxVariable(Variable):
-    def __init__(self, name="", order=1, family=1, block="", initial_condition=""):
+    def __init__(self, name="",order=None, family=None, block=None, initial_condition=None):
         super().__init__(name, order, family, block, initial_condition)
 
 class Variables():
@@ -55,8 +61,8 @@ class Variables():
         self.name = "Variables"
         self.variables = {}
 
-    def add_variable(self, name, **kwargs):
-        variable = Variable(name=name, **kwargs)
+    def add_variable(self, name, order, family, block, initial_condition):
+        variable = Variable(name=name, order=order,family=family,block=block, initial_condition=initial_condition)
         if variable.name in self.variables.keys():
             print("variable name already in use")
             

--- a/moose/variables.py
+++ b/moose/variables.py
@@ -28,32 +28,35 @@ class Family(IntEnum):
     SIDE_HIERARCHIC = auto()
     
 class Variable():
-    def __init__(self, name = "", order = 1, family = 1, block = ""):
+    def __init__(self, name="", order=1, family=1, block="", initial_condition=""):
         self.name = name
         self.order = Order(order)
         self.family = Family(family)
         self.block = block
+        self.initial_condition = initial_condition
 
     def __str__(self):
         string = f'[{self.name}]\n'
         string += f'order = {self.order.name}\n'
         string += f'family = {self.family.name}\n'
+        if self.initial_condition:
+            string += f'initial_condition = "{self.initial_condition}"\n'
         if self.block:
             string += f'block = "{self.block}"\n'
         string += f'[]\n'
         return string
 
 class AuxVariable(Variable):
-    def __init__(self, name = "", order = 1, family = 1, block = ""):
-        super().__init__(name,order,family,block)
+    def __init__(self, name="", order=1, family=1, block="", initial_condition=""):
+        super().__init__(name, order, family, block, initial_condition)
 
 class Variables():
     def __init__(self):
         self.name = "Variables"
         self.variables = {}
 
-    def add_variable(self, name, order, family, block):
-        variable = Variable(name=name,order=order,family=family,block=block)
+    def add_variable(self, name, order, family, block="", initial_condition=""):
+        variable = Variable(name=name, order=order, family=family, block=block, initial_condition=initial_condition)
         if variable.name in self.variables.keys():
             print("variable name already in use")
             
@@ -69,5 +72,6 @@ class Variables():
 class AuxVariables(Variables):
     def __init__(self):
         super().__init__()
-        self.name = "AuxVariables"    
+        self.name = "AuxVariables"
+   
         


### PR DESCRIPTION
**Motivation:**
To allow Moopy to run (for example renaming the "type" keyword argument). Also to allow for Helen's hcll-thermal.i file to be generated the way she wrote it.

**Changes:**

- keyword "type" changed -> kernel_type or mesh_type in kernels.oy and mesh.py respectively because command line through errors about the keyword type. 

- added "show_info" argument in mesh.py as it was needed in hcll-thermal.i

- added "initial_condition" argument variables.py as it was needed in hcll-thermal.i

- added "function=" in ParsedAux in kernels.py so it is written to the file (was made but not written, but is supposed to be like all the other strings above and below it)

- added problem.py so a problem block can be written (as it was in hcll-thermal.i)

- added new line in variables.py because a new line was supposed to be there but wasn't 

- variables.py takes kwargs now because "family" wasn't in hcll-thermal.i but required by moopy and moose didn't run with family=none. so I think making it generic with kwargs will keep it more versatile for other input files (not sure what the requirements are so a generic one will fit them all)

- quotations are now around prop_names and prop _values in materials.py, because they are needed for MOOSE to run.

**Behaviour:**
hcll-thermal.i is generated as it was given to me and successfully runs on MOOSE